### PR TITLE
Add in_group and has_attribute policy functions

### DIFF
--- a/src/abbey/functions/has_attribute.rego
+++ b/src/abbey/functions/has_attribute.rego
@@ -1,3 +1,5 @@
+package abbey.functions
+
 import future.keywords.if
 
 has_attribute(name, value) := true if {

--- a/src/abbey/functions/has_attribute.rego
+++ b/src/abbey/functions/has_attribute.rego
@@ -2,6 +2,9 @@ package abbey.functions
 
 import future.keywords.if
 
+# Function which checks whether a user has a given attribute
+# Attributes are found under a custom_attributes object under the
+# abbey.identities object
 has_attribute(name, value) := true if {
 	data.system.abbey.identities.directory_sync_users.custom_attributes[name] == value
 }

--- a/src/abbey/functions/has_attribute.rego
+++ b/src/abbey/functions/has_attribute.rego
@@ -2,9 +2,9 @@ package abbey.functions
 
 import future.keywords.if
 
-# Function which checks whether a user has a given attribute
+# Function which checks whether a user has a given attribute.
 # Attributes are found under a custom_attributes object under the
-# abbey.identities object
+# abbey.identities object.
 has_attribute(name, value) := true if {
 	data.system.abbey.identities.directory_sync_users.custom_attributes[name] == value
 }

--- a/src/abbey/functions/has_attribute.rego
+++ b/src/abbey/functions/has_attribute.rego
@@ -1,0 +1,5 @@
+import future.keywords.if
+
+has_attribute(name, value) := true if {
+	data.system.abbey.identities.directory_sync_users.custom_attributes[name] == value
+}

--- a/src/abbey/functions/has_attribute_test.rego
+++ b/src/abbey/functions/has_attribute_test.rego
@@ -1,0 +1,19 @@
+package abbey.functions
+
+import future.keywords.if
+
+test_has_cost_center_engineering if {
+    has_attribute("cost_center_name", "Engineering") with data.system.abbey.identities.directory_sync_users.custom_attributes as {"department_name": "Engineering", "cost_center_name": "Engineering", "employee_type": "Manager"}
+}
+
+test_has_department_engineering if {
+    has_attribute("department_name", "Engineering") with data.system.abbey.identities.directory_sync_users.custom_attributes as {"department_name": "Engineering", "cost_center_name": "Engineering", "employee_type": "Manager"}
+}
+
+test_does_not_have_department_marketing if {
+    not has_attribute("department_name", "Marketing") with data.system.abbey.identities.directory_sync_users.custom_attributes as {"department_name": "Engineering", "cost_center_name": "Engineering", "employee_type": "Manager"}
+}
+
+test_does_not_have_employee_type_ic if {
+    not has_attribute("employee_type", "IC") with data.system.abbey.identities.directory_sync_users.custom_attributes as {"department_name": "Engineering", "cost_center_name": "Engineering", "employee_type": "Manager"}
+}

--- a/src/abbey/functions/in_group.rego
+++ b/src/abbey/functions/in_group.rego
@@ -3,7 +3,7 @@ package abbey.functions
 import future.keywords.if
 import future.keywords.in
 
-# Function which checks whether a user is in a given group
+# Function which checks whether a user is in a given group.
 # Groups are kept within an object called group_memberships in the
 # system.abbey object
 in_group(group_name) := true if {

--- a/src/abbey/functions/in_group.rego
+++ b/src/abbey/functions/in_group.rego
@@ -1,3 +1,5 @@
+package abbey.functions
+
 import future.keywords.if
 import future.keywords.in
 

--- a/src/abbey/functions/in_group.rego
+++ b/src/abbey/functions/in_group.rego
@@ -1,0 +1,7 @@
+import future.keywords.if
+import future.keywords.in
+
+in_group(group_name) := true if {
+	some group in data.system.abbey.group_memberships
+	group == group_name
+}

--- a/src/abbey/functions/in_group.rego
+++ b/src/abbey/functions/in_group.rego
@@ -3,7 +3,9 @@ package abbey.functions
 import future.keywords.if
 import future.keywords.in
 
+# Function which checks whether a user is in a given group
+# Groups are kept within an object called group_memberships in the
+# system.abbey object
 in_group(group_name) := true if {
-	some group in data.system.abbey.group_memberships
-	group == group_name
+	group_name in data.system.abbey.group_memberships
 }

--- a/src/abbey/functions/in_group_test.rego
+++ b/src/abbey/functions/in_group_test.rego
@@ -1,0 +1,11 @@
+package abbey.functions
+
+import future.keywords.if
+
+test_in_group_engineering if {
+    in_group("Engineering") with data.system.abbey.group_memberships as ["Engineering", "R&D"]
+}
+
+test_not_in_group_marketing if {
+    not in_group("Marketing") with data.system.abbey.group_memberships as ["Engineering", "R&D"]
+}


### PR DESCRIPTION
This PR adds two policy functions.

1. in_group checks whether an Abbey user's identity is within a group

2. has_attribute checks whether an Abbey user has a custom attribute with a given value